### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.3|^8.0",
         "illuminate/support": "^5.5|^6|^7|^8",
         "illuminate/routing": "^5.5|^6|^7|^8",
         "illuminate/database": "^5.5|^6|^7|^8",


### PR DESCRIPTION
 Problem 1
    - rap2hpoutre/fast-excel[v1.6, ..., v1.7.0] require php ^7.0 -> your php version (8.0.3) does not satisfy that requirement.
    - yajra/laravel-address v0.4.0 requires rap2hpoutre/fast-excel ^1.6 -> satisfiable by rap2hpoutre/fast-excel[v1.6, v1.6.1, v1.7.0].
    - Root composer.json requires yajra/laravel-address ^0.4.0 -> satisfiable by yajra/laravel-address[v0.4.0].

https://stackoverflow.com/questions/65454412/root-composer-json-requires-php-7-3-but-your-php-version-8-0-0-does-not-satis

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines](https://github.com/yajra/laravel-address/blob/master/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
